### PR TITLE
Use gRPC custom logger

### DIFF
--- a/lib/transport/provider/grpc/index.js
+++ b/lib/transport/provider/grpc/index.js
@@ -408,6 +408,14 @@ function buildProtobuf(files) {
   return builder;
 }
 
+function setGRPCLogger(logger) {
+  // gRPC logger
+  const grpcLogger = {
+    error: logger.info,
+  };
+  grpc.setLogger(grpcLogger);
+}
+
 /**
  * Server is a gRPC transport provider for serving.
  *
@@ -428,6 +436,9 @@ function Server(config, logger) {
   this.$config = config;
   this.$logger = logger;
   this.$server = new grpc.Server();
+
+  // gRPC logger
+  setGRPCLogger(logger);
 
   // build protobuf
   const protoRoot = config.protoRoot || path.join(process.cwd(), 'protos');
@@ -538,6 +549,9 @@ function Client(config, logger) {
   if (!_.has(config, 'service')) {
     throw new Error('client is missing service config field');
   }
+
+  // gRPC logger
+  setGRPCLogger(logger);
 
   // build protobuf
   const protoRoot = config.protoRoot || path.join(process.cwd(), 'protos');


### PR DESCRIPTION
Requires a grpc release which includes the node custom logger.